### PR TITLE
test: fix bun test crash on Concordium Header export

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/bun-preload.ts"]

--- a/tests/bun-preload.ts
+++ b/tests/bun-preload.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck — bun:test is only resolved by `bun test` (CI), not tsc.
+import { mock } from "bun:test";
+
+/**
+ * `@concordium/web-sdk` publishes a `bun` export that points at TypeScript
+ * source. That source re-exports a type-only `Header`, which bun's test
+ * runner rejects (`Exported binding name 'Header' is not found`).
+ * Mock before tests load so CI `bun test` never evaluates that graph.
+ */
+class ExactConcordiumScheme {
+  config: unknown;
+  scheme = "exact";
+  constructor(_signer: unknown, config: unknown) {
+    this.config = config;
+  }
+}
+
+mock.module("@concordium/web-sdk", () => ({
+  AccountAddress: {
+    fromBase58(address: string) {
+      if (address === "not-an-address") {
+        throw new Error("invalid Concordium address");
+      }
+      return { address };
+    },
+  },
+  buildBasicAccountSigner(privateKey: string) {
+    return { privateKey };
+  },
+}));
+
+mock.module("@x402/concordium/exact/client", () => ({
+  ExactConcordiumScheme,
+}));


### PR DESCRIPTION
## Summary

CI (`ci-bun.yml`) runs `bun test`, not `vp test`. `bun test` loads `@concordium/web-sdk` via its `bun` export (TypeScript source). That source re-exports a type-only `Header`, which bun rejects:

`SyntaxError: Exported binding name 'Header' is not found.`

`tests/bun-preload.ts` mocks `@concordium/web-sdk` and `@x402/concordium/exact/client` before tests load.

## Test plan

- [x] `bun test tests` — 92 pass
- [x] `vp check`
- [x] `vp test tests` — 92 pass