### PR TITLE
chore: 1.0.0 and exclude 3rdparty from tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qntx/openai",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Drop-in OpenAI TypeScript client with transparent x402 payment support.",
   "keywords": [
     "ai",
@@ -17,7 +17,7 @@
   "author": "QNTX <x@qntx.fun>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/qntx/openai"
+    "url": "git+https://github.com/qntx/openai.git"
   },
   "files": [
     "dist"
@@ -146,7 +146,7 @@
     "packageManager": {
       "name": "bun",
       "version": "1.4.0",
-      "onFail": "download"
+      "onFail": "ignore"
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,7 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
-  }
+  },
+  "include": ["src", "tests", "examples", "vite.config.ts"],
+  "exclude": ["node_modules", "dist", "3rdparty"]
 }


### PR DESCRIPTION
## Summary

- Bump package to **1.0.0** (scoped `@qntx/openai` first release).
- `devEngines.packageManager.onFail: ignore` so `npm publish` is not blocked by bun-only engines.
- Normalize `repository.url` for npm.
- Exclude `3rdparty/` from `tsconfig.json` so local x402 clone is not pulled into dts emit.

Already published as `@qntx/openai@1.0.0`. This lands the matching git state on `main`. Do **not** tag `v1.0.0` (would re-trigger publish).

## Test plan

- [x] `vp check`
- [x] `vp pack` (no TS7056 from 3rdparty)
- [ ] CI