### PR TITLE
ci: pin qntx/workflows @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
-    uses: qntx/workflows/.github/workflows/ci-bun.yml@main
+    uses: qntx/workflows/.github/workflows/ci-bun.yml@v2
+    permissions:
+      contents: read

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,20 @@
+# Caller owns on:. Pin at @v2.
+# Enable "Allow auto-merge" on the repository. This workflow does not approve.
+# If branch protection requires reviews, add a ruleset bypass for dependabot
+# or pass TOKEN (a PAT/App) that can enable auto-merge. Do not checkout the PR.
+name: Dependabot
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: qntx/workflows/.github/workflows/ops-dependabot.yml@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags: ["v*.*.*"]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
-    uses: qntx/workflows/.github/workflows/publish-npm-bun.yml@main
+    uses: qntx/workflows/.github/workflows/publish-npm.yml@v2.0.0
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      package-manager: bun

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,4 +10,6 @@ permissions:
 
 jobs:
   release:
-    uses: qntx/workflows/.github/workflows/release.yml@main
+    uses: qntx/workflows/.github/workflows/release.yml@v2.0.0
+    permissions:
+      contents: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,13 @@ on:
     - cron: "30 1 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
-    uses: qntx/workflows/.github/workflows/repo-stale.yml@main
+    uses: qntx/workflows/.github/workflows/ops-stale.yml@v2
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
Mechanical cutover to qntx/workflows @v2 / @v2.0.0.

- `ci-bun.yml@v2`
- `publish-npm.yml@v2.0.0` with `package-manager: bun` and OIDC (`id-token: write`)
- `release.yml@v2.0.0`, `ops-stale.yml@v2`
- Dependabot auto-merge caller