### PR TITLE
chore: bump @qntx/openai to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qntx/openai",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Drop-in OpenAI TypeScript client with transparent x402 payment support.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

`@qntx/openai@1.0.0` is already on npm (local publish, gitHead `664f47f`). Tagging `v1.0.0` would republish the same version and fail.

Bump to **1.0.1** so `git tag v1.0.1 && git push origin v1.0.1` can trigger `.github/workflows/publish.yml` (OIDC + provenance).