### PR TITLE
feat: add local Monad exact and upto examples

### DIFF
--- a/examples/local-monad-exact.ts
+++ b/examples/local-monad-exact.ts
@@ -1,0 +1,55 @@
+/**
+ * Local o402 exact settlement on Monad (mainnet or testnet).
+ *
+ * Hits POST /v1/images/generations (o402 bills that path exact) against the
+ * local echo upstream (`exact-echo`).
+ *
+ * Usage:
+ *   bun --env-file=.env examples/local-monad-exact.ts
+ *   NETWORK=eip155:10143 bun --env-file=.env examples/local-monad-exact.ts
+ */
+
+import { preferNetwork, preferScheme, X402OpenAI } from "../src/index.ts";
+
+const network = (process.env.NETWORK ?? "eip155:143") as
+  | "eip155:143"
+  | "eip155:10143";
+const key = process.env.EVM_PRIVATE_KEY as `0x${string}` | undefined;
+if (!key) throw new Error("EVM_PRIVATE_KEY is required");
+
+const rpcUrl =
+  network === "eip155:10143"
+    ? "https://testnet-rpc.monad.xyz"
+    : "https://rpc.monad.xyz";
+
+const client = new X402OpenAI({
+  evm: { privateKey: key, rpcUrl },
+  baseURL: process.env.O402_BASE_URL ?? "http://127.0.0.1:8080/v1",
+  apiKey: "x402",
+  maxRetries: 0,
+  spendControls: {
+    maxAmountPerPayment: "$1",
+    allowedAssets: [
+      {
+        network: "eip155:10143",
+        asset: "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+      },
+    ],
+  },
+  policies: [preferNetwork(network), preferScheme("exact")],
+});
+
+const image = await client.images.generate({
+  model: "exact-echo",
+  prompt: `exact ${network}`,
+  n: 1,
+  size: "256x256",
+});
+
+console.log(JSON.stringify({
+  network,
+  model: "exact-echo",
+  scheme: "exact",
+  created: image.created,
+  url: image.data?.[0]?.url,
+}, null, 2));

--- a/examples/local-monad-matrix.ts
+++ b/examples/local-monad-matrix.ts
@@ -1,0 +1,85 @@
+/**
+ * Exercise exact + upto on Monad mainnet and testnet against local o402.
+ *
+ * Usage: bun --env-file=.env examples/local-monad-matrix.ts
+ */
+
+import { preferNetwork, preferScheme, X402OpenAI } from "../src/index.ts";
+
+const key = process.env.EVM_PRIVATE_KEY as `0x${string}` | undefined;
+if (!key) throw new Error("EVM_PRIVATE_KEY is required");
+
+const baseURL = process.env.O402_BASE_URL ?? "http://127.0.0.1:8080/v1";
+const chatModel = process.env.MODEL ?? "openrouter/meta-llama/llama-3.1-8b-instruct";
+const networks = ["eip155:143", "eip155:10143"] as const;
+
+function rpcUrl(network: (typeof networks)[number]): string {
+  return network === "eip155:10143"
+    ? "https://testnet-rpc.monad.xyz"
+    : "https://rpc.monad.xyz";
+}
+
+function client(
+  network: (typeof networks)[number],
+  scheme: "exact" | "upto",
+): X402OpenAI {
+  return new X402OpenAI({
+    evm: { privateKey: key, rpcUrl: rpcUrl(network) },
+    baseURL,
+    apiKey: "x402",
+    maxRetries: 0,
+    spendControls: {
+      maxAmountPerPayment: "$1",
+      allowedAssets: [
+        {
+          network: "eip155:10143",
+          asset: "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+        },
+      ],
+    },
+    policies: [preferNetwork(network), preferScheme(scheme)],
+  });
+}
+
+const unpaid = new X402OpenAI({
+  evm: key,
+  baseURL,
+  apiKey: "x402",
+  maxRetries: 0,
+});
+const models = await unpaid.models.list();
+const ids: string[] = [];
+for await (const model of models) ids.push(model.id);
+console.log("models", ids.slice(0, 12));
+
+for (const network of networks) {
+  const upto = client(network, "upto");
+  try {
+    const chat = await upto.chat.completions.create({
+      model: chatModel,
+      messages: [{ role: "user", content: `One word for ${network}` }],
+      max_tokens: 8,
+      stream: false,
+    });
+    console.log("upto ok", {
+      network,
+      content: chat.choices[0]?.message.content,
+      usage: chat.usage,
+    });
+  } catch (error) {
+    console.error("upto fail", network, error);
+  }
+
+  const exact = client(network, "exact");
+  try {
+    const image = await exact.images.generate({
+      model: "exact-echo",
+      prompt: `exact ${network}`,
+      n: 1,
+      size: "256x256",
+    });
+    console.log("exact ok", { network, url: image.data?.[0]?.url });
+  } catch (error) {
+    console.error("exact fail", network, error);
+  }
+}

--- a/examples/local-monad-upto.ts
+++ b/examples/local-monad-upto.ts
@@ -1,0 +1,53 @@
+/**
+ * Local o402 upto chat on Monad (mainnet or testnet).
+ *
+ * Usage:
+ *   bun --env-file=.env examples/local-monad-upto.ts
+ *   NETWORK=eip155:10143 bun --env-file=.env examples/local-monad-upto.ts
+ */
+
+import { preferNetwork, preferScheme, X402OpenAI } from "../src/index.ts";
+
+const network = (process.env.NETWORK ?? "eip155:143") as
+  | "eip155:143"
+  | "eip155:10143";
+const key = process.env.EVM_PRIVATE_KEY as `0x${string}` | undefined;
+if (!key) throw new Error("EVM_PRIVATE_KEY is required");
+
+const rpcUrl =
+  network === "eip155:10143"
+    ? "https://testnet-rpc.monad.xyz"
+    : "https://rpc.monad.xyz";
+
+const client = new X402OpenAI({
+  evm: { privateKey: key, rpcUrl },
+  baseURL: process.env.O402_BASE_URL ?? "http://127.0.0.1:8080/v1",
+  apiKey: "x402",
+  maxRetries: 0,
+  spendControls: {
+    maxAmountPerPayment: "$1",
+    allowedAssets: [
+      {
+        network: "eip155:10143",
+        asset: "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+      },
+    ],
+  },
+  policies: [preferNetwork(network), preferScheme("upto")],
+});
+
+const model = process.env.MODEL ?? "openrouter/meta-llama/llama-3.1-8b-instruct";
+const response = await client.chat.completions.create({
+  model,
+  messages: [{ role: "user", content: `Reply with one word: ${network}` }],
+  max_tokens: 16,
+  stream: false,
+});
+
+console.log(JSON.stringify({
+  network,
+  model,
+  scheme: "upto",
+  content: response.choices[0]?.message.content,
+  usage: response.usage,
+}, null, 2));


### PR DESCRIPTION
## 中文

### 问题

本地要把 o402 + facilitator 在 Monad 主网（`eip155:143`）和测试网（`eip155:10143`）上跑通 **exact** 和 **upto**。仓库里已有的 `chat-evm.ts` / `chat-upto.ts`：

1. 默认打生产 `https://llm.qntx.org/v1`，不是 `http://127.0.0.1:8080/v1`。
2. 没有 `preferNetwork`，402 里主网排第一时会一直付主网。
3. `@x402/evm` 的 default assets **没有** Monad 测试网 USDC（`0x534b2f3A21130d7a60830c2Df862319e593943A3`）。默认 spend controls 会丢掉测试网 accept，`preferNetwork("eip155:10143")` 匹配为空后 passthrough，结果测试网请求实际 settle 在主网。
4. chat completions 在 o402 里按路径记 **upto**；exact 必须打 `/v1/images/generations` 这类路径。已有示例覆盖不到 exact。

### 为什么要改

需要可重复的本地矩阵：两条网 × 两种 scheme，密钥只从环境变量读。测试网 USDC 必须出现在 `spendControls.allowedAssets` 里，policy 才能真正锁住 `eip155:10143`。`rpcUrl` 按网切换，便于 Permit2 allowance 检查 / 自批准。

### 改动

- `examples/local-monad-upto.ts`：chat completions（upto），`NETWORK` 默认 `eip155:143`。
- `examples/local-monad-exact.ts`：`images.generate` → o402 exact 路径，upstream 为本地 echo。
- `examples/local-monad-matrix.ts`：四格都跑。
- 允许测试网 USDC；私钥仅 `EVM_PRIVATE_KEY`。

### 用法

```bash
bun --env-file=.env examples/local-monad-upto.ts
NETWORK=eip155:10143 bun --env-file=.env examples/local-monad-exact.ts
```

`.env` 已被 gitignore，不要把私钥提交进仓库。

---

## English

### Problem

Local o402 + facilitator must exercise **exact** and **upto** on Monad mainnet (`eip155:143`) and testnet (`eip155:10143`). Existing `chat-evm.ts` / `chat-upto.ts`:

1. Default `baseURL` is production `https://llm.qntx.org/v1`.
2. No `preferNetwork`, so `accepts[0]` (mainnet) always wins.
3. `@x402/evm` default assets omit Monad testnet USDC (`0x534b2f3A21130d7a60830c2Df862319e593943A3`). Spend controls drop that accept; `preferNetwork("eip155:10143")` matches nothing and passthrough-pays mainnet.
4. o402 bills `POST /v1/chat/completions` as **upto**. Exact needs another exported path (`/v1/images/generations`). Old examples never hit exact.

### Why this change

Need a repeatable local matrix: two nets × two schemes, keys from env only. Testnet USDC must be in `spendControls.allowedAssets` or the policy cannot pin `eip155:10143`. Per-net `rpcUrl` is required for Permit2 allowance reads / self-approve.

### Changes

- `examples/local-monad-upto.ts` — chat completions (upto).
- `examples/local-monad-exact.ts` — `images.generate` against o402 exact + local echo.
- `examples/local-monad-matrix.ts` — all four cells.
- Allow testnet USDC; private key only via `EVM_PRIVATE_KEY`.

### Usage

```bash
bun --env-file=.env examples/local-monad-upto.ts
NETWORK=eip155:10143 bun --env-file=.env examples/local-monad-exact.ts
```

`.env` is gitignored. Do not commit keys.
